### PR TITLE
Fix Page Number

### DIFF
--- a/LZUthesis.cls
+++ b/LZUthesis.cls
@@ -75,7 +75,8 @@
     \thispagestyle{mainmatterstyle}
 }
 \AtBeginDocument{\addtocontents{toc}{\protect\thispagestyle{empty}}}
-
+\AtBeginDocument{\addtocontents{lof}{\protect\thispagestyle{empty}}}
+\AtBeginDocument{\addtocontents{lot}{\protect\thispagestyle{empty}}}
 
 
 %=======format

--- a/LZUthesis.cls
+++ b/LZUthesis.cls
@@ -43,7 +43,8 @@
 \RequirePackage{etoolbox}
 \pagestyle{fancy}          % Enables the custom headers/footers
 
-\fancypagestyle{frontmatterstyle}{
+% 前置页版式
+\fancypagestyle{frontmatterstyle}{ 
     \fancyhf{}
     \renewcommand{\headrulewidth}{0pt}
 
@@ -73,7 +74,7 @@
 \fancypagestyle{plain}{
     \thispagestyle{mainmatterstyle}
 }
-\AtBeginDocument{\addtocontents{toc}{\protect\thispagestyle{frontmatterstyle}}}
+\AtBeginDocument{\addtocontents{toc}{\protect\thispagestyle{empty}}}
 
 
 
@@ -232,8 +233,11 @@
 \newcommand{\ZhAbstract}[2]{%
     \phantomsection
     \addcontentsline{toc}{chapter}{中文摘要}
-    \thispagestyle{frontmatterstyle}
+   % \thispagestyle{frontmatterstyle}
    % \thispagestyle{empty}
+   \thispagestyle{plain}
+   \setcounter{page}{1}
+    \pagenumbering{Roman}
     \begin{center}%
         \setlength{\parskip}{24pt}
         \begin{minipage}{0.8\textwidth}
@@ -361,7 +365,8 @@
 \newcommand{\Grade}{
 \clearpage
 \phantomsection
-\addcontentsline{toc}{chapter}{论文（设计）成绩}
+\thispagestyle{empty}
+%\addcontentsline{toc}{chapter}{论文（设计）成绩}
 \begin{center}
     \zihao{-3}\bfseries\songti
     \begin{tabularx}{\textwidth}{|X|}
@@ -395,7 +400,7 @@
 
 
 
-%\AtBeginDocument{\addtocontents{toc}{\protect\thispagestyle{frontmatterstyle}}}
+%\AtBeginDocument{\addtocontents{toc}{\protect\thispagestyle{empty}}}
 
 %item style
 \usepackage{enumitem}

--- a/template.tex
+++ b/template.tex
@@ -82,12 +82,20 @@
 
 
 %生成目录
+\addtocontents{toc}{\protect\thispagestyle{empty}}
 \tableofcontents
 %插入图或表的目录
+
 \renewcommand\listfigurename{插\ 图\ 目\ 录}
 \renewcommand\listtablename{表\ 格\ 目\ 录}
+%\addtocontents{lof}{\protect\thispagestyle{empty}}
 \listoffigures
+\thispagestyle{empty}
+\newpage
+%\addtocontents{lot}{\protect\thispagestyle{empty}}
 \listoftables
+\thispagestyle{empty}
+\newpage
 %文章主体
 \mainmatter
 

--- a/template.tex
+++ b/template.tex
@@ -88,14 +88,14 @@
 
 \renewcommand\listfigurename{插\ 图\ 目\ 录}
 \renewcommand\listtablename{表\ 格\ 目\ 录}
-%\addtocontents{lof}{\protect\thispagestyle{empty}}
+\addtocontents{lof}{\protect\thispagestyle{empty}}
 \listoffigures
-\thispagestyle{empty}
-\newpage
-%\addtocontents{lot}{\protect\thispagestyle{empty}}
+%\thispagestyle{empty}
+%\newpage
+\addtocontents{lot}{\protect\thispagestyle{empty}}
 \listoftables
-\thispagestyle{empty}
-\newpage
+%\thispagestyle{empty}
+%\newpage
 %文章主体
 \mainmatter
 


### PR DESCRIPTION
根据兰州大学官方模板要求
**封面、目录不编排页码，中英文摘要页用罗马数字单独连续编号，引言、正文用阿拉伯数字连续编号，附录可不编排页码。**
对LZUthesis.cls和template.tex进行相应修改

## 效果

对多页主目录页进行测试，均不再显示页码；单页图、表目录页也不再显示页码，多页有待测试（因为我图或表都列不到2页...），应该多页也没问题的。